### PR TITLE
Make installable as a package

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 John W. Miller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,41 @@
+# Spoonacular API
+# Copyright 2018 John W. Miller
+# See LICENSE for details.
+
+import re
+import os
+from setuptools import find_packages, setup
+
+VERSIONFILE = "spoonacular/__init__.py"
+ver_file = open(VERSIONFILE, "rt").read()
+VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
+mo = re.search(VSRE, ver_file, re.M)
+
+if mo:
+    version = mo.group(1)
+else:
+    raise RuntimeError(
+        "Unable to find version string in {}".format(VERSIONFILE))
+
+here = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(here, 'README.md')) as f:
+    README = f.read()
+
+setup(name="spoonacular",
+      version=version,
+      description="A Python wrapper for the Spoonacular API",
+      long_description=README,
+      long_description_content_type="text/markdown",
+      license="MIT",
+      author="John W. Miller",
+      url="https://github.com/johnwmillr/SpoonacularAPI",
+      packages=find_packages(exclude=['tests']),
+      install_requires=["requests"],
+      keywords="spoonacular API food recipes ingredients cuisine groceries",
+      python_requires=">=3.*",
+      classifiers=[
+              'Topic :: Software Development :: Libraries',
+          'Operating System :: OS Independent',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 3',
+      ])


### PR DESCRIPTION
This PR adds the `setup.py` file necessary for installing `spoonacular` as a Python package. Hoping to get ownership of the [`spoonacular`](https://pypi.org/project/spoonacular/) package on PyPI before uploading this package there.